### PR TITLE
Fix for overwriting original data property

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,16 +46,14 @@ module.exports = function (options) {
       return cb();
     }
 
-	// Support generating context per-file
-	if (typeof data === 'function') {
-		data = data(file);
-	}
+    // Support generating context per-file
+    var contextData = typeof data === 'function' ? data(file) : data;
 
     try {
       var finalName = typeof name === 'function' && name(file) || file.relative;
       var tmpl = dust.compileFn(file.contents.toString(), finalName);
       var that = this;
-      tmpl(data, function(err, out){
+      tmpl(contextData, function(err, out){
         if (err){
           that.emit('error', new gutil.PluginError('gulp-dust', err));
           return; 


### PR DESCRIPTION
I was overwriting the data variable, which meant that if multiple files were processed the data function was being overwritten and the data generated from the first run was being used for any additional files.

Sorry about that.